### PR TITLE
Add Gradle Wrapper update workflow.

### DIFF
--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -1,0 +1,14 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    name: Update Gradle Wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Add a GitHub workflow to automatically update the Gradle Wrapper daily using a cron schedule. This ensures the project always uses the latest stable Gradle version, improving build reliability and security.