### PR TITLE
Update Gradle Wrapper daily with GitHub workflow

### DIFF
--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  workflow_call:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    name: Update Gradle Wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Added a GitHub workflow to automatically update the Gradle Wrapper on a daily schedule using a cron job. This ensures the project consistently uses the latest stable Gradle version, enhancing build reliability and security.